### PR TITLE
fix move anim script download

### DIFF
--- a/python/MovScrCMDDecompiler.py
+++ b/python/MovScrCMDDecompiler.py
@@ -7,6 +7,7 @@ import json
 AddressesPerEntry = 0xE
 
 move_file_location = argv[2]
+script_names = argv[5].split(",")
 print(move_file_location)
 
 move_data = {}
@@ -73,15 +74,25 @@ with open(argv[1], 'rb') as SCRIPT:
     print(f'.align 4')
     print()
     print(f'.word {Count} @ Count')
+
+    if (Count == 1):
+        script_names[0] = "SCRIPT"
+    else:
+        if (len(script_names) < Count):
+            for Index in range(len(script_names(script_names)), Count):
+                script_names[Index] = f"{Index}"
+        for Index in range(Count):
+            script_names[Index] = f"SCRIPT_{script_names[Index]}"
+
     for Index in range(Count):
         Addresses += set(unpack('<' + 'L' * AddressesPerEntry, SCRIPT.read(AddressesPerEntry * 0x4)))
-        for Address in Addresses:
-            for Pass in range(AddressesPerEntry):
-                print(f'.word SCRIPT_{Address}')
+        for Pass in range(AddressesPerEntry):
+            print(f'.word {script_names[Index]}')
+
     print()
-    for Address in Addresses:
-        SCRIPT.seek(Address)
-        print(f'SCRIPT_{Address}:')
+    for Index in range(Count):
+        SCRIPT.seek(Addresses[Index])
+        print(f'{script_names[Index]}:')
         while True:
             CommandIndex = unpack('<H', SCRIPT.read(0x2))[0]
             CommandData = CommandSet[CommandIndex]

--- a/python/move_writer.py
+++ b/python/move_writer.py
@@ -86,7 +86,7 @@ def get_script_names(readable):
 		return ["IDLE", "ATTACK"]
 
 	# Thief
-	if (readable["index"] == 158):
+	if (readable["index"] == 168):
 		return ["DEFAULT", "STEAL"]
 	
 	# Curse

--- a/python/move_writer.py
+++ b/python/move_writer.py
@@ -40,11 +40,20 @@ def output_narc(rom, rom_name):
 	return tools.output_narc("moves", rom, rom_name)
 
 def decompile_script(rom_name, move_id):
+	script_names = []
 	if move_id > 559:
 		ani = "battle_animations"
 		offset = 561
 	else:
 		ani = "move_animations"
+
+		json_file_path = f'{rom_data.ROM_NAME}/json/moves/{move_id}.json'
+		with open(json_file_path, "r", encoding='ISO8859-1') as outfile:  	
+			json_data = json.load(outfile)
+			if json_data["readable"] is not None:
+				readable = json_data["readable"]
+				script_names = get_script_names(readable)
+
 		offset = 0
 
 	with open(f'{rom_name}/session_settings.json', "r") as outfile:  
@@ -58,11 +67,56 @@ def decompile_script(rom_name, move_id):
 		f.write(script)
 		f.close()
 
-		subprocess.run(["python3", "python/MovScrCMDDecompiler.py", f"{rom_name}/move_scripts/{move_id}.bin", f"{rom_name}/json/moves/{move_id}.json" , '>', f"{rom_name}/move_scripts/{move_id}.txt"], check=True)
+		subprocess.run(["python3", "python/MovScrCMDDecompiler.py", f"{rom_name}/move_scripts/{move_id}.bin", f"{rom_name}/json/moves/{move_id}.json" , '>', f"{rom_name}/move_scripts/{move_id}.txt", ",".join(script_names)], check=True)
 		decompiled_script = open(f"{rom_name}/move_scripts/{move_id}.txt").read().splitlines()
 		remove_line_with_string(f"{rom_name}/move_scripts/{move_id}.txt", "project")
 
+def get_script_names(readable):
+	script_names = []
+
+	if (readable["requires_charge"]):
+		return ["CHARGE", "RELEASE"]
+
+	# Future Sight, Doom Desire
+	if (readable["index"] == 248 or readable["index"] == 353):
+		return ["USE", "ATTACK"]
+	
+	# Bide
+	if (readable["index"] == 117):
+		return ["IDLE", "ATTACK"]
+
+	# Thief
+	if (readable["index"] == 158):
+		return ["DEFAULT", "STEAL"]
+	
+	# Curse
+	if (readable["index"] == 174):
+		return ["NORMAL", "GHOST"]
+	
+	# Present
+	if (readable["index"] == 217):
+		return ["DAMAGE", "HEAL"]
+	
+	# Brick Break
+	if (readable["index"] == 280):
+		return ["DEFAULT", "Break"]
+	
+	# Weather Ball
+	if (readable["index"] == 311):
+		return ["NORMAL", "FIRE", "ICE", "ROCK", "WATER"]
+	
+	# Techno Blast
+	if (readable["index"] == 546):
+		return ["NORMAL", "WATER", "ELECTRIC", "FIRE", "ICE"]
+	
+	# Fusion Flare, Fusion Bolt
+	if (readable["index"] == 558 or readable["index"] == 559):
+		return ["DEFAULT", "COMBINED"]
+
+	return script_names
+
 def remove_line_with_string(file_path, string_to_remove):
+
     # Read the content of the file
     with open(file_path, 'r') as file:
         lines = file.readlines()


### PR DESCRIPTION
Move scripts contain a bug where the stored offsets for each subscript are duplicated more than necessary, causing issues with two-turn attacks and the following moves with multiple animations: Bide, Thief, Curse, Present, Future Sight, Brick Break, Weather Ball, Doom Desire, Techno Blast, Fusion Flare, and Fusion Bolt.

Scripts will now have more appropriate labels for subscripts. For example, Curse's subscripts will be labeled "SCRIPT_NORMAL" and "SCRIPT_GHOST" respectively.