### PR TITLE
DoSPACircleAnimation

### DIFF
--- a/B2W2_MOVSCRCMD.s
+++ b/B2W2_MOVSCRCMD.s
@@ -188,7 +188,7 @@
 .word \p12
 .endm
 
-.macro DoSPAMiscAnimation p0 p1 p2 p3 p4 p5 p6
+.macro DoSPACircleAnimation p0 p1 p2 p3 p4 p5 p6 p7 p8 p9
 .hword 16
 .word \p0
 .word \p1
@@ -197,6 +197,9 @@
 .word \p4
 .word \p5
 .word \p6
+.word \p7
+.word \p8
+.word \p9
 .endm
 
 .macro CMD_11 p0 p1 p2 p3 p4 p5 p6

--- a/tools/movecommands/MOV_SCRCMD.yml
+++ b/tools/movecommands/MOV_SCRCMD.yml
@@ -315,6 +315,12 @@
       Type: int
     - Name: p6
       Type: int
+    - Name: p7
+      Type: int
+    - Name: p8
+      Type: int
+    - Name: p9
+      Type: int
 17:
   Name: CMD_11
   Parameters:

--- a/tools/movecommands/MOV_SCRCMD.yml
+++ b/tools/movecommands/MOV_SCRCMD.yml
@@ -299,7 +299,7 @@
     - Name: p12
       Type: int
 16:
-  Name: DoSPAMiscAnimation
+  Name: DoSPACircleAnimation
   Parameters:
     - Name: p0
       Type: int


### PR DESCRIPTION
Renamed DoSPAMiscAnimation to DoSPACircleAnimation and changed the number of parameters from 7 to the correct 10.