### PR TITLE
Secret Power Fix

### DIFF
--- a/python/move_writer.py
+++ b/python/move_writer.py
@@ -101,6 +101,10 @@ def get_script_names(readable):
 	if (readable["index"] == 280):
 		return ["DEFAULT", "Break"]
 	
+	# Secret Power
+	if (readable["index"] == 290):
+		return ["BODYSLAM", "MUDSLAP", "MUDSHOT", "AVALANCHE", "ICESHARD", "WATERPULSE", "ROCKTHROW", "NEEDLEARM"]
+	
 	# Weather Ball
 	if (readable["index"] == 311):
 		return ["NORMAL", "FIRE", "ICE", "ROCK", "WATER"]

--- a/tools/movecommands/MOV_SCRCMD.yml
+++ b/tools/movecommands/MOV_SCRCMD.yml
@@ -949,6 +949,7 @@
   Parameters:
     - Name: p0
       Type: int
+  End: true
 75:
   Name: CMD_4b
   Parameters:


### PR DESCRIPTION
Secret Power had a bug where the downloaded animation script displayed incorrectly. It now displays as intended. This fix also updates the "CallMoveAnimation" (which is used exclusively by Secret Power and Bide) command to end the script, just like TerminateMoveScript.