### PR TITLE
StopSound CMD name change

### DIFF
--- a/B2W2_MOVSCRCMD.s
+++ b/B2W2_MOVSCRCMD.s
@@ -532,7 +532,7 @@
 .word \p7
 .endm
 
-.macro StopSound p0 p1 p2 p3 p4 p5 p6 p7 p8
+.macro AdjustSound p0 p1 p2 p3 p4 p5 p6 p7 p8
 .hword 55
 .word \p0
 .word \p1

--- a/tools/movecommands/MOV_SCRCMD.yml
+++ b/tools/movecommands/MOV_SCRCMD.yml
@@ -792,7 +792,7 @@
     - Name: p7
       Type: int
 55:
-  Name: StopSound
+  Name: AdjustSound
   Parameters:
     - Name: p0
       Type: int


### PR DESCRIPTION
Changed the name of the StopSound CMD to AdjustSound to better represent what the cmd actually does since it does more than silent sound effects